### PR TITLE
[FIX] Add sudo to virtual_available

### DIFF
--- a/stock_virtual_available_adj/__manifest__.py
+++ b/stock_virtual_available_adj/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Stock Virtual Available Adjust',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.2.0',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Warehouse',

--- a/stock_virtual_available_adj/models/product_template.py
+++ b/stock_virtual_available_adj/models/product_template.py
@@ -22,3 +22,13 @@ class ProductTemplate(models.Model):
                 pt.website_sale_available_qty += pp.virtual_available - \
                                                  pp.sent_sale_qty - \
                                                  pp.draft_sale_qty
+
+    # Since access to stock.move model is being restricted by marketplace
+    # module, sudo() is needed for seller accounts.
+    def _compute_quantities(self):
+        res = self.sudo()._compute_quantities_dict()
+        for template in self:
+            template.qty_available = res[template.id]['qty_available']
+            template.virtual_available = res[template.id]['virtual_available']
+            template.incoming_qty = res[template.id]['incoming_qty']
+            template.outgoing_qty = res[template.id]['outgoing_qty']


### PR DESCRIPTION
@yostashiro Here is the PR to add sudo to the compute method of virtual_available.
However, without this method, my development environment is still able to show correct "In Stock" or "Out of Stock" status of a product. Probably there is some issue with my environment, but can you have a quick check on this?