### PR TITLE
[FIX] Remove youtube module from dependency

### DIFF
--- a/product_carousel_image_attachment/__manifest__.py
+++ b/product_carousel_image_attachment/__manifest__.py
@@ -14,7 +14,7 @@
 corresponding product.image record for the attached file.
     """,
     'depends': [
-        'product_video_player',
+        'base',
     ],
     'installable': True,
 }


### PR DESCRIPTION
@yostashiro I was not expecting the `product_video_player` is the dependency of this module? May I know your intention?