### PR TITLE
[IMP] Add publish button to product details page

### DIFF
--- a/website_sale_adj/__manifest__.py
+++ b/website_sale_adj/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Website Sales Adjustment',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.1.1',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Product',

--- a/website_sale_adj/views/templates.xml
+++ b/website_sale_adj/views/templates.xml
@@ -17,4 +17,18 @@
             <p><font class="text-gamma" style="">Products that left in the cart for over two days will be removed.</font></p>
         </xpath>
     </template>
+
+    <template id="product" name="Product Publish Button"
+              inherit_id="website_sale.product">
+        <xpath expr="//div[@id='website_published_button']"
+               position="inside">
+            <t t-call="website.publish_management"
+               groups="sales_team.group_sale_manager">
+                <t t-set="object" t-value="product"/>
+                <t t-set="publish_edit" t-value="True"/>
+                <t t-set="action" t-value="'product.product_template_action'"/>
+            </t>
+        </xpath>
+    </template>
+
 </odoo>


### PR DESCRIPTION
Adding https://github.com/odoo/odoo/blob/61c9921596662a2cbc15a154a91dd2f52c9854fd/addons/website_sale/views/templates.xml#L96-L100 to the product_details page