### PR TITLE
[IMP] Add website_sale_available_qty to the product list view

### DIFF
--- a/stock_virtual_available_adj/__manifest__.py
+++ b/stock_virtual_available_adj/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Stock Virtual Available Adjust',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.2.0',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Warehouse',
@@ -16,6 +16,7 @@ calculation.
     'depends': [
         'stock',
         'website_sale',
+        'product_ext_sst',
     ],
     'data': [
         'views/product_views.xml',

--- a/stock_virtual_available_adj/i18n/ja.po
+++ b/stock_virtual_available_adj/i18n/ja.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-04 08:35+0000\n"
-"PO-Revision-Date: 2018-05-04 08:35+0000\n"
+"POT-Creation-Date: 2018-06-12 09:21+0000\n"
+"PO-Revision-Date: 2018-06-12 09:21+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,3 +19,9 @@ msgstr ""
 #: model:ir.ui.view,arch_db:stock_virtual_available_adj.product_template_website_sale_available_qty_button
 msgid "<span class=\"o_stat_text\">Website Available</span>"
 msgstr "<span class=\"o_stat_text\">EC利用可能数量</span>"
+
+#. module: stock_virtual_available_adj
+#: model:ir.model.fields,field_description:stock_virtual_available_adj.field_product_product_website_sale_available_qty
+#: model:ir.model.fields,field_description:stock_virtual_available_adj.field_product_template_website_sale_available_qty
+msgid "Available Quantity in eCommerce"
+msgstr "EC利用可能数量"

--- a/stock_virtual_available_adj/views/product_views.xml
+++ b/stock_virtual_available_adj/views/product_views.xml
@@ -22,4 +22,16 @@
         </field>
     </record>
 
+    <record model="ir.ui.view" id="sale_product_template_tree_view">
+        <field name="name">sale.product.template.product.tree</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id"
+               ref="product_ext_sst.sale_product_template_tree_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='staff_in_charge']" position="after">
+               <field name="website_sale_available_qty"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Adding the `website_sale_available_qty` to the product list view defined by `product_ext_sst`, i.e. https://github.com/rfhk/sts-custom/blob/9b465becc2a032463fe11b231a16ae36be08ce7f/product_ext_sst/views/product_template_views.xml#L71-L101