### PR TITLE
[FIX] Add ir.rule, fix function name

### DIFF
--- a/odoo_product_connector/__manifest__.py
+++ b/odoo_product_connector/__manifest__.py
@@ -30,6 +30,7 @@
         'python': ['odoorpc'],
     },
     'data':[
+        'security/ir.model.access.csv',
         'wizard/product_sync_view.xml',
         'views/product_view.xml',
         'views/res_company_view.xml',

--- a/odoo_product_connector/models/product.py
+++ b/odoo_product_connector/models/product.py
@@ -42,7 +42,7 @@ class Product(models.Model):
         for product_data in data:
             # connection = odoolib.get_connection(hostname=HOSTNAME, database=DATABASE, \
             #             login=USER, password=PASSWORD)
-            odoo = odoorpc.Odoo(HOSTNAME, port=8069)
+            odoo = odoorpc.ODOO(HOSTNAME, port=8069)
             odoo.login(DATABASE, USER, PASSWORD)
             product_id = self.browse(int(data[product_data].get('product_id')))
 

--- a/odoo_product_connector/security/ir.model.access.csv
+++ b/odoo_product_connector/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sync_history_user,access_sync_history_user,model_product_sync_history,base.group_user,1,1,1,1


### PR DESCRIPTION
- `product.sync.history` does not have any `ir.rule` rule which will cause error when user tries to open the `product.product` form view
- replace `odoorpc.Odoo` by `odoorpc.ODOO` 