### PR TITLE
[FIX] Inherit from website_sale_options instead from website_sale

### DIFF
--- a/website_sale_login_required/controllers/main.py
+++ b/website_sale_login_required/controllers/main.py
@@ -3,10 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import http, tools, _
-from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website_sale_options.controllers.main import WebsiteSaleOptions
 
 
-class WebsiteSale(WebsiteSale):
+class WebsiteSale(WebsiteSaleOptions):
 
     @http.route([
         '/shop',


### PR DESCRIPTION
- Since `website_sale_options` also inheriting the controllers of `website_sale`, the order of executing the inheriting controllers is not consistent. 
e.g. `website_sale_options` > `website_sale_login_required` > `website_sale` => Product page will be shown
`website_sale_login_required` > `website_sale_options` > `website_sale` => Login page will be shown



ref: https://github.com/odoo/odoo/blob/42264d8dcb7f8d0795c84718d1fc9a5fd1aefd32/addons/website_sale_options/controllers/main.py#L6-L15
