### PR TITLE
[IMP] Add product_type to stock quant for search

### DIFF
--- a/stock_quant_list_view/i18n/ja.po
+++ b/stock_quant_list_view/i18n/ja.po
@@ -45,3 +45,14 @@ msgstr "販売候補"
 #: model:ir.ui.menu,name:stock_quant_list_view.menu_stock_quant
 msgid "Stock Quant"
 msgstr "店舗在庫"
+
+#. module: stock_quant_list_view
+#: model:ir.ui.view,arch_db:stock_quant_list_view.quant_search_view
+msgid "Stockable"
+msgstr "在庫可能"
+
+#. module: stock_quant_list_view
+#: model:ir.model.fields,field_description:stock_quant_list_view.field_stock_quant_product_type
+msgid "Product Type"
+msgstr "プロダクトタイプ"
+

--- a/stock_quant_list_view/models/stock_quant.py
+++ b/stock_quant_list_view/models/stock_quant.py
@@ -12,3 +12,7 @@ class StockQuant(models.Model):
         related='product_tmpl_id.team_ids',
         string='Sales Channels',
     )
+    product_type = fields.Selection(
+        related='product_tmpl_id.type',
+        store=True,
+    )

--- a/stock_quant_list_view/views/stock_quant_views.xml
+++ b/stock_quant_list_view/views/stock_quant_views.xml
@@ -17,6 +17,7 @@
                 <field name="quantity" string="On Hand"/>
                 <field name="product_uom_id" groups="product.group_uom"/>
                 <field name='company_id' groups="base.group_multi_company"/>
+                <field name="product_type" invisible="1"/>
             </tree>
         </field>
     </record>
@@ -41,6 +42,18 @@
          <field name="view_id" ref="view_stock_quant_tree"/>
          <field name="context">{'search_default_internal_loc': 1, 'search_default_stockable': 1}</field>
          <field name="search_view_id" ref="stock.quant_search_view"/>
+    </record>
+
+    <record id="quant_search_view" model="ir.ui.view">
+        <field name="name">stock.quant.search</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.quant_search_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='stockable']"
+                   position="replace">
+                <filter name="stockable" string="Stockable" domain="[('product_type', '=', 'product')]"/>
+            </xpath>
+        </field>
     </record>
 
     <menuitem action="action_stock_quant"


### PR DESCRIPTION
- Add `product_type` as a related field to `stock.quant`
- Adjust the default `stockable` filter so that it will filter on the new field, i.e.  `product_type`