### PR TITLE
[FIX] Remove onchange after creation

### DIFF
--- a/stock_quant_sale_order/wizard/stock_quant_sale_order.py
+++ b/stock_quant_sale_order/wizard/stock_quant_sale_order.py
@@ -76,7 +76,6 @@ class QuantSaleOrderWizard(models.TransientModel):
             'warehouse_id': warehouse_id.id,
         }
         sale_order = sale_order_obj.sudo().create(order_vals)
-        sale_order.onchange_partner_id()
         sale_order.user_id = self.env.uid
 
         for quant in quant_ids:

--- a/stock_quant_sale_order/wizard/stock_quant_sale_order.py
+++ b/stock_quant_sale_order/wizard/stock_quant_sale_order.py
@@ -76,6 +76,8 @@ class QuantSaleOrderWizard(models.TransientModel):
             'warehouse_id': warehouse_id.id,
         }
         sale_order = sale_order_obj.sudo().create(order_vals)
+        sale_order.onchange_partner_id()
+        sale_order.team_id = self.team_id.id
         sale_order.user_id = self.env.uid
 
         for quant in quant_ids:


### PR DESCRIPTION
- Since `onchange_partner_id()` is used to update some user-related fields when the partner is changed. It will overwrite the `team_id` of the sales order which should be defined in the wizard instead.