### PR TITLE
[ADD] website_sale_remove_product_penalty

### DIFF
--- a/website_sale_remove_product_penalty/__init__.py
+++ b/website_sale_remove_product_penalty/__init__.py
@@ -1,0 +1,2 @@
+
+from . import models

--- a/website_sale_remove_product_penalty/__manifest__.py
+++ b/website_sale_remove_product_penalty/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Website Order Remove Product Penalty',
+    'version': '11.0.1.0.0',
+    'author': 'Quartile Limited',
+    'website': 'https://www.quartile.co',
+    'category': 'Website',
+    'license': "AGPL-3",
+    'description': """
+Internal user can assign a transaction fee product to online cart when
+portal user tires to remove a product from the cart.
+    """,
+    'depends': [
+        'sales_team',
+        'website_sale',
+    ],
+    'data': [
+        'views/res_config_settings_views.xml',
+        'views/templates.xml',
+    ],
+    'installable': True,
+}

--- a/website_sale_remove_product_penalty/i18n/ja.po
+++ b/website_sale_remove_product_penalty/i18n/ja.po
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* website_sale_remove_product_penalty
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-09-12 09:12+0000\n"
+"PO-Revision-Date: 2018-09-12 09:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_sale_remove_product_penalty
+#: model:ir.model.fields,field_description:website_sale_remove_product_penalty.field_res_config_settings_penalty_product_id
+#: model:ir.model.fields,field_description:website_sale_remove_product_penalty.field_webkul_website_addons_penalty_product_id
+#: model:ir.model.fields,field_description:website_sale_remove_product_penalty.field_website_order_notes_settings_penalty_product_id
+msgid "Cart Product Removal Penalty"
+msgstr "カート削除ペナルティ"
+
+#. module: website_sale_remove_product_penalty
+#: model:ir.ui.view,arch_db:website_sale_remove_product_penalty.res_config_settings_view_form
+msgid "Cart Removal Penalty"
+msgstr "カート削除ペナルティ"
+
+#. module: website_sale_remove_product_penalty
+#: model:ir.model.fields,field_description:website_sale_remove_product_penalty.field_sale_order_line_is_penalty
+msgid "Is a Penalty"
+msgstr "ペナルティ"
+
+#. module: website_sale_remove_product_penalty
+#: model:ir.ui.view,arch_db:website_sale_remove_product_penalty.res_config_settings_view_form
+msgid "Penalty Product For Removing Products From Cart"
+msgstr "カートからプロダクトを削除する場合のペナルティプロダクト"
+
+#. module: website_sale_remove_product_penalty
+#: model:ir.model,name:website_sale_remove_product_penalty.model_sale_order
+msgid "Quotation"
+msgstr "見積"
+
+#. module: website_sale_remove_product_penalty
+#: model:ir.ui.view,arch_db:website_sale_remove_product_penalty.res_config_settings_view_form
+msgid "Removal Penalty"
+msgstr "ペナルティプロダクト"
+
+#. module: website_sale_remove_product_penalty
+#: model:ir.model,name:website_sale_remove_product_penalty.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "販売オーダ明細"
+
+#. module: website_sale_remove_product_penalty
+#: model:ir.model,name:website_sale_remove_product_penalty.model_res_config_settings
+msgid "res.config.settings"
+msgstr "res.config.settings"

--- a/website_sale_remove_product_penalty/models/__init__.py
+++ b/website_sale_remove_product_penalty/models/__init__.py
@@ -1,0 +1,4 @@
+
+from . import res_config_settings
+from . import sale_order
+from . import sale_order_line

--- a/website_sale_remove_product_penalty/models/res_config_settings.py
+++ b/website_sale_remove_product_penalty/models/res_config_settings.py
@@ -1,0 +1,28 @@
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    penalty_product_id = fields.Many2one(
+        'product.product',
+        string='Cart Product Removal Penalty'
+    )
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+        get_param = self.env['ir.config_parameter'].sudo().get_param
+        res.update(penalty_product_id = int(get_param(
+            'website_sale_remove_product_penalty.penalty_product_id',
+            default=False)))
+        return res
+
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        set_param = self.env['ir.config_parameter'].sudo().set_param
+        set_param('website_sale_remove_product_penalty.penalty_product_id',
+                  self.penalty_product_id.id)

--- a/website_sale_remove_product_penalty/models/sale_order.py
+++ b/website_sale_remove_product_penalty/models/sale_order.py
@@ -1,0 +1,32 @@
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    # Follows the set_delivery_line in the website_sale_delivery
+    def _create_order_line(self, product_id):
+        # Apply fiscal position
+        taxes = product_id.taxes_id.filtered(
+            lambda t: t.company_id.id == self.company_id.id)
+        taxes_ids = taxes.ids
+        if self.partner_id and self.fiscal_position_id:
+            taxes_ids = self.fiscal_position_id.map_tax(
+                taxes, product_id, self.partner_id).ids
+        # Create the penalty product order line
+        values = {
+            'order_id': self.id,
+            'product_uom_qty': 1,
+            'product_uom': product_id.uom_id.id,
+            'product_id': product_id.id,
+            'price_unit': product_id.list_price,
+            'tax_id': [(6, 0, taxes_ids)],
+            'is_penalty': True
+        }
+        if self.order_line:
+            values['sequence'] = self.order_line[-1].sequence + 1
+        sol = self.env['sale.order.line'].sudo().create(values)
+        return sol

--- a/website_sale_remove_product_penalty/models/sale_order_line.py
+++ b/website_sale_remove_product_penalty/models/sale_order_line.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    is_penalty = fields.Boolean(string="Is a Penalty", default=False)
+
+    @api.multi
+    def unlink(self):
+        penalty_product_id = self.env['ir.config_parameter'].sudo().get_param(
+            'website_sale_remove_product_penalty.penalty_product_id')
+        if penalty_product_id:
+            penalty_product = self.env['product.product'].browse([
+                int(penalty_product_id)])[0]
+            for order_line in self:
+                if order_line.order_id and order_line.team_id == self.env.ref(
+                        'sales_team.salesteam_website_sales') and \
+                                order_line.product_id.type == 'product':
+                    # Check the sales order and see if there is already a
+                    # penalty product order line
+                    penalty_flag = False
+                    for sale_order_line in order_line.order_id.order_line:
+                        if sale_order_line.product_id == penalty_product:
+                            sale_order_line.product_uom_qty += 1
+                            penalty_flag = True
+                    # Add a new penalty order line
+                    if not penalty_flag:
+                        order_line.order_id._create_order_line(penalty_product)
+        res = super(SaleOrderLine, self).unlink()
+        return res

--- a/website_sale_remove_product_penalty/views/res_config_settings_views.xml
+++ b/website_sale_remove_product_penalty/views/res_config_settings_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <div id="checkout_assignation_setting" position="after">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="penalty_product_setting" groups="base.group_no_one">
+                    <div class="o_setting_right_pane">
+                        <label string="Cart Removal Penalty"/>
+                        <div class="text-muted">
+                            Penalty Product For Removing Products From Cart
+                        </div>
+                        <div class="content-group">
+                            <div class="row mt16">
+                                <label class="o_light_label col-md-3" string="Removal Penalty" for="penalty_product_id"/>
+                                <!--<field name="penalty_product_id"-->
+                                       <!--domain="[('type', '=', 'service')]"/>-->
+                                <field name="penalty_product_id"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>

--- a/website_sale_remove_product_penalty/views/templates.xml
+++ b/website_sale_remove_product_penalty/views/templates.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="cart_lines" inherit_id="website_sale.cart_lines">
+        <xpath expr="//div[@class='css_quantity input-group oe_website_spinner']"
+               position="attributes">
+            <attribute name="t-if">not line.is_penalty</attribute>
+        </xpath>
+        <xpath expr="//div[@class='css_quantity input-group oe_website_spinner']"
+               position="after">
+            <div class="css_quantity text-center" t-if="line.is_penalty">
+                <span t-field="line.product_uom_qty" style="white-space: nowrap;"/>
+            </div>
+        </xpath>
+        <xpath expr="//a[@class='js_delete_product hidden-xs no-decoration']"
+               position="attributes">
+            <attribute name="t-if">not line.is_penalty</attribute>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
- When a product is being removed from the cart from the website, `unlink()` will be triggered. Therefore in case the product is a "Stockable" product and it is an online quotation, i.e. "Website Sales" as the sales channel, a penalty product will be added to the quotation.