### PR TITLE
[FIX] Add sudo() to browse records for portal users

### DIFF
--- a/website_sale_remove_product_penalty/controllers/main.py
+++ b/website_sale_remove_product_penalty/controllers/main.py
@@ -13,7 +13,8 @@ class WebsiteSale(WebsiteSale):
     def cart_update_json(self, product_id, line_id=None, add_qty=None,
                          set_qty=None, display=True):
         if line_id and set_qty != None and not add_qty:
-            sale_order_line = request.env['sale.order.line'].browse(line_id)
+            sale_order_line = request.env['sale.order.line'].sudo().browse(
+                line_id)
             penalty_product_id = request.env[
                 'ir.config_parameter'].sudo().get_param(
                 'website_sale_remove_product_penalty.penalty_product_id')
@@ -22,7 +23,7 @@ class WebsiteSale(WebsiteSale):
             if sale_order_line.product_uom_qty > set_qty and \
                     penalty_product_id and sale_order_line.product_id.type \
                     == 'product':
-                penalty_product = request.env['product.product'].browse([
+                penalty_product = request.env['product.product'].sudo().browse([
                     int(penalty_product_id)])[0]
                 # Get the quantity removed from the cart
                 quantity = sale_order_line.product_uom_qty - set_qty


### PR DESCRIPTION
- For portal users, make sure they have the permission to browse the product and sales order lines records.