### PR TITLE
[ADD] website_sale_invoice_filter_adj

### DIFF
--- a/website_sale_invoice_filter_adj/__init__.py
+++ b/website_sale_invoice_filter_adj/__init__.py
@@ -1,0 +1,2 @@
+
+from . import controllers

--- a/website_sale_invoice_filter_adj/__manifest__.py
+++ b/website_sale_invoice_filter_adj/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Portal Page Invoice Domain Adjustments',
+    'version': '11.0.1.0.0',
+    'author': 'Quartile Limited',
+    'website': 'https://www.quartile.co',
+    'category': 'Website',
+    'license': "AGPL-3",
+    'description': """
+This module restricts the access of account invoice in the portal page.
+    """,
+    'summary': "",
+    'depends': [
+        'account',
+    ],
+    'data': [
+    ],
+    'installable': True,
+}

--- a/website_sale_invoice_filter_adj/controllers/__init__.py
+++ b/website_sale_invoice_filter_adj/controllers/__init__.py
@@ -1,0 +1,2 @@
+
+from . import portal

--- a/website_sale_invoice_filter_adj/controllers/portal.py
+++ b/website_sale_invoice_filter_adj/controllers/portal.py
@@ -1,0 +1,21 @@
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.http import request
+from odoo.addons.account.controllers.portal import PortalAccount
+
+
+class PortalAccount(PortalAccount):
+
+    # Overwrite standard method, only invoices that the customer is related
+    # to the user will be shown.
+    def _get_account_invoice_domain(self):
+        partner = request.env.user.partner_id
+        domain = [
+            ('type', 'in', ['out_invoice', 'out_refund']),
+            # ('message_partner_ids', 'child_of',
+            # [partner.commercial_partner_id.id]),
+            ('partner_id', 'child_of', [partner.commercial_partner_id.id]),
+            ('state', 'in', ['open', 'paid', 'cancel'])
+        ]
+        return domain


### PR DESCRIPTION
- Adjust `_get_account_invoice_domain` so that only invoices that the customer is related to the user will be shown in the portal page