### PR TITLE
[FIX] propagate date_planned to order lines

### DIFF
--- a/purchase_ext_sst/models/purchase_order.py
+++ b/purchase_ext_sst/models/purchase_order.py
@@ -192,6 +192,8 @@ class PurchaseOrder(models.Model):
                                   'default guest user.'))
             if not purchase_order.date_planned:
                 purchase_order.date_planned = fields.Datetime.now()
+                for order_line in purchase_order.order_line:
+                    order_line.date_planned = purchase_order.date_planned
         return super(PurchaseOrder, self).button_confirm()
 
     def check_onchange_phone(self, phone, field):
@@ -277,3 +279,9 @@ class PurchaseOrder(models.Model):
                                                 user_id=False,
                                                 company_id=company_id) or False
         return partner_id == default_id
+
+    @api.onchange('date_planned')
+    def onchange_date_planned(self):
+        if self.date_planned:
+            for order_line in self.order_line:
+                order_line.date_planned = self.date_planned

--- a/purchase_ext_sst/models/purchase_order_line_hook_onchange_product_id.py
+++ b/purchase_ext_sst/models/purchase_order_line_hook_onchange_product_id.py
@@ -18,7 +18,9 @@ def onchange_product_id(self):
         return result
 
     # Reset date, price and quantity since _onchange_quantity will provide default values
-    self.date_planned = datetime.today().strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+    self.date_planned = datetime.today().strftime(
+        DEFAULT_SERVER_DATETIME_FORMAT) if not self.order_id.date_planned \
+        else self.order_id.date_planned
     # Modified by QTL >>>
     # self.price_unit = self.product_qty = 0.0
     self.product_qty = 0.0

--- a/purchase_ext_sst/views/purchase_order_views.xml
+++ b/purchase_ext_sst/views/purchase_order_views.xml
@@ -60,7 +60,7 @@
                 <field name="purchased_by_id"/>
             </xpath>
             <xpath expr="//notebook/page[1]//tree/field[@name='date_planned']" position="attributes">
-                <attribute name="invisible">True</attribute>
+                <attribute name="invisible">False</attribute>
             </xpath>
             <xpath expr="//notebook/page[2]//field[@name='date_planned']" position="attributes">
                 <attribute name="required">False</attribute>

--- a/purchase_ext_sst/views/purchase_order_views.xml
+++ b/purchase_ext_sst/views/purchase_order_views.xml
@@ -60,7 +60,7 @@
                 <field name="purchased_by_id"/>
             </xpath>
             <xpath expr="//notebook/page[1]//tree/field[@name='date_planned']" position="attributes">
-                <attribute name="invisible">False</attribute>
+                <attribute name="invisible">True</attribute>
             </xpath>
             <xpath expr="//notebook/page[2]//field[@name='date_planned']" position="attributes">
                 <attribute name="required">False</attribute>


### PR DESCRIPTION
- Add onchanged method to `date_planned` of purchase order.
- Adjust the method that set the default value of purchase order line.

Operation Pattern:
1. Create purchase order > create purchase order line > confirm order. (Handled by overriding `button_confirm`)
2. Create purchase order > create purchase order line > Input order's date planned > confirm order. (Handled by adding `onchange_date_planned`)
3. Create purchase order > Input order's date planned > create purchase order line > confirm order.  (Handled by overriding `onchange_product_id`)