### PR TITLE
[IMP] Add country_id as state domain

### DIFF
--- a/purchase_post_code_propose_address_sst/models/purchase_order.py
+++ b/purchase_post_code_propose_address_sst/models/purchase_order.py
@@ -12,6 +12,10 @@ from odoo import models, fields, api, _
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
+    country_id = fields.Many2one(
+        string='Country',
+        default=lambda self: self.env.ref('base.jp')
+    )
     state_id = fields.Many2one(
         'res.country.state',
         string='Prefecture',

--- a/purchase_post_code_propose_address_sst/views/purchase_order_views.xml
+++ b/purchase_post_code_propose_address_sst/views/purchase_order_views.xml
@@ -10,6 +10,7 @@
                 <field name="zipcode"/>
                 <field name="city"/>
                 <field name="state_id" invisible="1"/>
+                <field name="country_id" invisible="1"/>
                 <field name="street"/>
                 <field name="street2"/>
             </xpath>
@@ -36,7 +37,8 @@
             <xpath expr="//field[@name='address']" position="replace">
                 <field name="zip"/>
                 <field name="zipcode"/>
-                <field name="state_id"/>
+                <field name="country_id" invisible="1"/>
+                <field name="state_id" domain="[('country_id','=',country_id)]"/>
                 <field name="city"/>
                 <field name="street"/>
                 <field name="street2"/>


### PR DESCRIPTION
- Add `country_id` to `purchase.order` and set default as `Japan` which will be used as the domain filter of the `state_id`.