### PR TITLE
[IMP] Use default_code as barcode in stock.quant

### DIFF
--- a/stock_ext_sst/models/stock_quant.py
+++ b/stock_ext_sst/models/stock_quant.py
@@ -24,7 +24,8 @@ class StockQuant(models.Model):
         auto_join=True,
     )
     barcode = fields.Char(
-        related='product_id.barcode',
+        related='product_id.default_code',
+        string='Barcode',
         store=True,
         readonly=True,
         index=True,


### PR DESCRIPTION
- The `barcode` field of some `stock.quant` records return empty. Try to use `default_code` for the `barcode` field.