### PR TITLE
[IMP] Use default_code field as barcode field in stock.quant

### DIFF
--- a/stock_ext_sst/i18n/ja.po
+++ b/stock_ext_sst/i18n/ja.po
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_ext_sst
-#: model:ir.model.fields,field_description:stock_ext_sst.field_stock_quant_barcode
+#: model:ir.model.fields,field_description:stock_ext_sst.field_stock_quant_default_code
 msgid "Barcode"
 msgstr "バーコード"
 

--- a/stock_ext_sst/models/stock_quant.py
+++ b/stock_ext_sst/models/stock_quant.py
@@ -23,8 +23,9 @@ class StockQuant(models.Model):
     product_id = fields.Many2one(
         auto_join=True,
     )
-    barcode = fields.Char(
-        related='product_id.barcode',
+    default_code = fields.Char(
+        related='product_id.default_code',
+        string='Barcode',
         store=True,
         readonly=True,
         index=True,

--- a/stock_ext_sst/views/stock_quant_views.xml
+++ b/stock_ext_sst/views/stock_quant_views.xml
@@ -21,7 +21,7 @@
         <field name="inherit_id" ref="stock.quant_search_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="before">
-                <field name="barcode"/>
+                <field name="default_code"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- The `barcode` field of some `stock.quant` records return empty. Try to use `default_code` for the `barcode` field.