### PR TITLE
change logic of generating the email record with multiple recipients

### DIFF
--- a/website_sale_product_subscribe_notify/__manifest__.py
+++ b/website_sale_product_subscribe_notify/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Odoo Product Subscribe Notify',
-    'version': '11.0.1.1.0',
+    'version': '11.0.2.0.0',
     'category' : 'Website',
     'license': 'Other proprietary',
     'summary': "Send notification to subscribers",
@@ -25,6 +25,7 @@ any following fields of the product is updated,
         'data/templates.xml',
         'views/member_group_views.xml',
         'views/product_public_category_view.xml',
+        'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
         'views/website_templates.xml',
     ],

--- a/website_sale_product_subscribe_notify/data/templates.xml
+++ b/website_sale_product_subscribe_notify/data/templates.xml
@@ -8,9 +8,6 @@
         <field name="partner_to">${ctx['partner_id']}</field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="body_html"><![CDATA[
-<p>Hello ${ctx['partner_name']}
-,</p>
-<p>
 <p style="color:#eeeeee;">
 <img src="/web/image/product.template/${object.id}/image" height="100px" width="100px"></img>
 </p>

--- a/website_sale_product_subscribe_notify/data/templates.xml
+++ b/website_sale_product_subscribe_notify/data/templates.xml
@@ -5,7 +5,7 @@
         <field name="name">product public category- Send by Email</field>
         <field name="email_from">${object.company_id.email}</field>
         <field name="subject">Product Information Update Notification (${object.get_website_name()})</field>
-        <field name="partner_to">${ctx['partner_id']}</field>
+        <field name="partner_to">${ctx['partner_ids']}</field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="body_html"><![CDATA[
 <p style="color:#eeeeee;">

--- a/website_sale_product_subscribe_notify/data/templates.xml
+++ b/website_sale_product_subscribe_notify/data/templates.xml
@@ -8,6 +8,7 @@
         <field name="partner_to">${ctx['partner_ids']}</field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="body_html"><![CDATA[
+<p>
 <p style="color:#eeeeee;">
 <img src="/web/image/product.template/${object.id}/image" height="100px" width="100px"></img>
 </p>

--- a/website_sale_product_subscribe_notify/i18n/ja.po
+++ b/website_sale_product_subscribe_notify/i18n/ja.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 11.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-25 03:50+0000\n"
-"PO-Revision-Date: 2018-07-25 03:50+0000\n"
+"POT-Creation-Date: 2019-11-08 10:24+0000\n"
+"PO-Revision-Date: 2019-11-08 10:24+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,10 +17,7 @@ msgstr ""
 
 #. module: website_sale_product_subscribe_notify
 #: model:mail.template,body_html:website_sale_product_subscribe_notify.email_template_product_public_category
-msgid "\n"
-"<p>Hello ${ctx['partner_name']}\n"
-",</p>\n"
-"<p>\n"
+msgid "<p>\n"
 "<p style=\"color:#eeeeee;\">\n"
 "    <img src=\"/web/image/product.template/${object.id}/image\" height=\"100px\" width=\"100px\"></img>\n"
 "</p>\n"
@@ -52,10 +49,7 @@ msgid "\n"
 "% endif\n"
 "</p>\n"
 ""
-msgstr "\n"
-"<p>${ctx['partner_name']}　様\n"
-"</p>\n"
-"<p>\n"
+msgstr "<p>\n"
 "<p style=\"color:#eeeeee;\">\n"
 "    <img src=\"/web/image/product.template/${object.id}/image\" height=\"100px\" width=\"100px\"></img>\n"
 "</p>\n"
@@ -127,6 +121,11 @@ msgid "Display Name"
 msgstr "表示名"
 
 #. module: website_sale_product_subscribe_notify
+#: model:ir.ui.view,arch_db:website_sale_product_subscribe_notify.res_config_settings_view_form
+msgid "Email Recipient Limit"
+msgstr "メール宛先制限"
+
+#. module: website_sale_product_subscribe_notify
 #: model:ir.model.fields,field_description:website_sale_product_subscribe_notify.field_member_group_name
 msgid "Group Name"
 msgstr "グループ名"
@@ -156,6 +155,7 @@ msgstr "最終更新日"
 #: model:ir.model.fields,field_description:website_sale_product_subscribe_notify.field_res_users_member_group_id
 #: model:ir.ui.menu,name:website_sale_product_subscribe_notify.menu_member_group
 #: model:ir.ui.view,arch_db:website_sale_product_subscribe_notify.form_view_member_group
+#: model:ir.ui.view,arch_db:website_sale_product_subscribe_notify.member_group_search_view
 msgid "Member Group"
 msgstr "メンバーグループ"
 
@@ -171,6 +171,18 @@ msgid "My Subscriptions"
 msgstr "お気に入りカテゴリ"
 
 #. module: website_sale_product_subscribe_notify
+#: model:ir.model.fields,field_description:website_sale_product_subscribe_notify.field_res_config_settings_email_recipient_limit
+#: model:ir.model.fields,field_description:website_sale_product_subscribe_notify.field_webkul_website_addons_email_recipient_limit
+#: model:ir.model.fields,field_description:website_sale_product_subscribe_notify.field_website_order_notes_settings_email_recipient_limit
+msgid "Number of Recipients Per Email"
+msgstr "メールの宛先数"
+
+#. module: website_sale_product_subscribe_notify
+#: model:ir.ui.view,arch_db:website_sale_product_subscribe_notify.res_config_settings_view_form
+msgid "Odoo Product Subscribe Notify"
+msgstr "商品更新のお知らせ"
+
+#. module: website_sale_product_subscribe_notify
 #: model:ir.model.fields,field_description:website_sale_product_subscribe_notify.field_member_group_point_limit
 msgid "Points Limit"
 msgstr "購読ポイントリミット"
@@ -183,7 +195,7 @@ msgstr "商品更新のお知らせ（${object.get_website_name()}）"
 #. module: website_sale_product_subscribe_notify
 #: model:ir.model,name:website_sale_product_subscribe_notify.model_product_template
 msgid "Product Template"
-msgstr "製品テンプレート"
+msgstr "プロダクトテンプレート"
 
 #. module: website_sale_product_subscribe_notify
 #: model:ir.ui.view,arch_db:website_sale_product_subscribe_notify.display_product_subscriptions
@@ -191,9 +203,14 @@ msgid "Return"
 msgstr "戻す"
 
 #. module: website_sale_product_subscribe_notify
+#: model:ir.ui.view,arch_db:website_sale_product_subscribe_notify.res_config_settings_view_form
+msgid "Set the maximun of recipients per email for Odoo Product Subscribe Notify"
+msgstr "「商品更新のお知らせ」メールの宛先制限を設定"
+
+#. module: website_sale_product_subscribe_notify
 #: model:ir.ui.view,arch_db:website_sale_product_subscribe_notify.display_product_subscriptions
 msgid "Submit"
-msgstr "確認"
+msgstr "申請"
 
 #. module: website_sale_product_subscribe_notify
 #: model:ir.model.fields,field_description:website_sale_product_subscribe_notify.field_product_public_category_subscribe_point
@@ -221,7 +238,7 @@ msgid "You have unsubscribed categories:"
 msgstr "下記のカテゴリに登録を解除しました："
 
 #. module: website_sale_product_subscribe_notify
-#: code:addons/website_sale_product_subscribe_notify/controller/main.py:73
+#: code:addons/website_sale_product_subscribe_notify/controller/main.py:76
 #, python-format
 msgid "You subscription point is not enough to subscribe the selected categories."
 msgstr "購読ポイントが足りません。ご確認してください。"
@@ -246,4 +263,8 @@ msgstr "member.group"
 msgid "pt&amp;nbsp;"
 msgstr "pt&amp;nbsp;"
 
+#. module: website_sale_product_subscribe_notify
+#: model:ir.model,name:website_sale_product_subscribe_notify.model_res_config_settings
+msgid "res.config.settings"
+msgstr "res.config.settings"
 

--- a/website_sale_product_subscribe_notify/models/__init__.py
+++ b/website_sale_product_subscribe_notify/models/__init__.py
@@ -3,4 +3,6 @@
 from . import member_group
 from . import product_public_category
 from . import product_template
+from . import res_config_settings
 from . import res_partner
+

--- a/website_sale_product_subscribe_notify/models/__init__.py
+++ b/website_sale_product_subscribe_notify/models/__init__.py
@@ -5,4 +5,3 @@ from . import product_public_category
 from . import product_template
 from . import res_config_settings
 from . import res_partner
-

--- a/website_sale_product_subscribe_notify/models/product_template.py
+++ b/website_sale_product_subscribe_notify/models/product_template.py
@@ -24,7 +24,6 @@ class ProductTemplate(models.Model):
                     partner_ids = rec.get_product_category_followers_ids()
                     partners = rec.env['res.partner'].browse(partner_ids)
                     list_price = "%d" % int(rec.list_price)
-                    limit_recipient = rec.get_limit_email_recipient()
                     ctx.update({
                             'website_published_update': vals.get(
                                 "website_published"),
@@ -34,7 +33,6 @@ class ProductTemplate(models.Model):
                             'list_price': list_price
                     })
                     template.with_context(ctx).send_mail(rec.id)
-                    print("limit_recipient", limit_recipient)
         return result
 
     def get_website_name(self):
@@ -48,6 +46,3 @@ class ProductTemplate(models.Model):
                 set(partner_ids)
             )
         return partner_ids
-
-    def get_limit_email_recipient(self):
-        return self.env['website'].browse(['limit_email_recipient '])

--- a/website_sale_product_subscribe_notify/models/product_template.py
+++ b/website_sale_product_subscribe_notify/models/product_template.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
+import math
 
 
 class ProductTemplate(models.Model):
@@ -25,9 +26,8 @@ class ProductTemplate(models.Model):
                     partners = rec.env['res.partner'].browse(partner_ids)
                     list_price = "%d" % int(rec.list_price)
                     limit_recipient = rec.env['ir.default'].get('res.config.settings', 'email_recipient_limit')
-                    number_of_loop = len(partners)/limit_recipient
-                    if number_of_loop%1 != 0 : number_of_loop += 1 
-                    for n in range(int(number_of_loop)):
+                    number_of_loop = math.ceil(len(partners)/float(limit_recipient))
+                    for n in range(number_of_loop):
                         ctx.update({
                             'website_published_update': vals.get(
                                 "website_published"),

--- a/website_sale_product_subscribe_notify/models/product_template.py
+++ b/website_sale_product_subscribe_notify/models/product_template.py
@@ -26,17 +26,15 @@ class ProductTemplate(models.Model):
                     list_price = "%d" % int(rec.list_price)
                     limit_recipient = rec.env['ir.default'].get('res.config.settings', 'email_recipient_limit')
                     number_of_loop = len(partners)/limit_recipient
-                    if number_of_loop%1 != 0 :
-                        number_of_loop += 1 
-                        print("float",number_of_loop)
+                    if number_of_loop%1 != 0 : number_of_loop += 1 
                     for n in range(int(number_of_loop)):
                         ctx.update({
-                                'website_published_update': vals.get(
-                                    "website_published"),
-                                'list_price_update': vals.get("list_price"),
-                                'description_sale_update': vals.get("description_sale"),
-                                'partner_ids': ','.join([str(partner.id) for partner in partners[n*limit_recipient:(n+1)*limit_recipient]]),
-                                'list_price': list_price
+                            'website_published_update': vals.get(
+                                "website_published"),
+                            'list_price_update': vals.get("list_price"),
+                            'description_sale_update': vals.get("description_sale"),
+                            'partner_ids': ','.join([str(partner.id) for partner in partners[n*limit_recipient:(n+1)*limit_recipient]]),
+                            'list_price': list_price
                         })
                         template.with_context(ctx).send_mail(rec.id)
         return result

--- a/website_sale_product_subscribe_notify/models/product_template.py
+++ b/website_sale_product_subscribe_notify/models/product_template.py
@@ -25,17 +25,20 @@ class ProductTemplate(models.Model):
                     partners = rec.env['res.partner'].browse(partner_ids)
                     list_price = "%d" % int(rec.list_price)
                     limit_recipient = rec.env['ir.default'].get('res.config.settings', 'email_recipient_limit')
-                    number_of_loop = round(len(partners)/limit_recipient)
-
-                    ctx.update({
-                            'website_published_update': vals.get(
-                                "website_published"),
-                            'list_price_update': vals.get("list_price"),
-                            'description_sale_update': vals.get("description_sale"),
-                            'partner_ids': ','.join([str(partner.id) for partner in partners[:limit_recipient]]),
-                            'list_price': list_price
-                    })
-                    template.with_context(ctx).send_mail(rec.id)
+                    number_of_loop = len(partners)/limit_recipient
+                    if number_of_loop%1 != 0 :
+                        number_of_loop += 1 
+                        print("float",number_of_loop)
+                    for n in range(int(number_of_loop)):
+                        ctx.update({
+                                'website_published_update': vals.get(
+                                    "website_published"),
+                                'list_price_update': vals.get("list_price"),
+                                'description_sale_update': vals.get("description_sale"),
+                                'partner_ids': ','.join([str(partner.id) for partner in partners[n*limit_recipient:(n+1)*limit_recipient]]),
+                                'list_price': list_price
+                        })
+                        template.with_context(ctx).send_mail(rec.id)
         return result
 
     def get_website_name(self):

--- a/website_sale_product_subscribe_notify/models/product_template.py
+++ b/website_sale_product_subscribe_notify/models/product_template.py
@@ -24,12 +24,15 @@ class ProductTemplate(models.Model):
                     partner_ids = rec.get_product_category_followers_ids()
                     partners = rec.env['res.partner'].browse(partner_ids)
                     list_price = "%d" % int(rec.list_price)
+                    limit_recipient = rec.env['ir.default'].get('res.config.settings', 'email_recipient_limit')
+                    number_of_loop = round(len(partners)/limit_recipient)
+
                     ctx.update({
                             'website_published_update': vals.get(
                                 "website_published"),
                             'list_price_update': vals.get("list_price"),
                             'description_sale_update': vals.get("description_sale"),
-                            'partner_ids': ','.join([str(partner.id) for partner in partners]),
+                            'partner_ids': ','.join([str(partner.id) for partner in partners[:limit_recipient]]),
                             'list_price': list_price
                     })
                     template.with_context(ctx).send_mail(rec.id)

--- a/website_sale_product_subscribe_notify/models/product_template.py
+++ b/website_sale_product_subscribe_notify/models/product_template.py
@@ -25,8 +25,10 @@ class ProductTemplate(models.Model):
                     partner_ids = rec.get_product_category_followers_ids()
                     partners = rec.env['res.partner'].browse(partner_ids)
                     list_price = "%d" % int(rec.list_price)
-                    limit_recipient = rec.env['ir.default'].get('res.config.settings', 'email_recipient_limit')
-                    number_of_loop = math.ceil(len(partners)/float(limit_recipient))
+                    limit_recipient = rec.env['ir.default'].get(
+                        'res.config.settings', 'email_recipient_limit')
+                    number_of_loop = math.ceil(
+                        len(partners)/float(limit_recipient))
                     for n in range(number_of_loop):
                         ctx.update({
                             'website_published_update': vals.get(

--- a/website_sale_product_subscribe_notify/models/product_template.py
+++ b/website_sale_product_subscribe_notify/models/product_template.py
@@ -24,19 +24,17 @@ class ProductTemplate(models.Model):
                     partner_ids = rec.get_product_category_followers_ids()
                     partners = rec.env['res.partner'].browse(partner_ids)
                     list_price = "%d" % int(rec.list_price)
-                    multi_partner_id = ''
-                    for partner in partners:
-                        multi_partner_id = multi_partner_id + str(partner.id) + ','
+                    limit_recipient = rec.get_limit_email_recipient()
                     ctx.update({
                             'website_published_update': vals.get(
                                 "website_published"),
                             'list_price_update': vals.get("list_price"),
                             'description_sale_update': vals.get("description_sale"),
-                            'partner_name': partner.name,
-                            'partner_id': multi_partner_id,
+                            'partner_ids': ','.join([str(partner.id) for partner in partners]),
                             'list_price': list_price
                     })
                     template.with_context(ctx).send_mail(rec.id)
+                    print("limit_recipient", limit_recipient)
         return result
 
     def get_website_name(self):
@@ -50,3 +48,6 @@ class ProductTemplate(models.Model):
                 set(partner_ids)
             )
         return partner_ids
+
+    def get_limit_email_recipient(self):
+        return self.env['website'].browse(['limit_email_recipient '])

--- a/website_sale_product_subscribe_notify/models/product_template.py
+++ b/website_sale_product_subscribe_notify/models/product_template.py
@@ -24,17 +24,19 @@ class ProductTemplate(models.Model):
                     partner_ids = rec.get_product_category_followers_ids()
                     partners = rec.env['res.partner'].browse(partner_ids)
                     list_price = "%d" % int(rec.list_price)
+                    multi_partner_id = ''
                     for partner in partners:
-                        ctx.update({
+                        multi_partner_id = multi_partner_id + str(partner.id) + ','
+                    ctx.update({
                             'website_published_update': vals.get(
                                 "website_published"),
                             'list_price_update': vals.get("list_price"),
                             'description_sale_update': vals.get("description_sale"),
                             'partner_name': partner.name,
-                            'partner_id': partner.id,
+                            'partner_id': multi_partner_id,
                             'list_price': list_price
-                        })
-                        template.with_context(ctx).send_mail(rec.id)
+                    })
+                    template.with_context(ctx).send_mail(rec.id)
         return result
 
     def get_website_name(self):

--- a/website_sale_product_subscribe_notify/models/res_config_settings.py
+++ b/website_sale_product_subscribe_notify/models/res_config_settings.py
@@ -26,6 +26,6 @@ class ResConfigSettings(models.TransientModel):
 
     @api.constrains('email_recipient_limit')
     def _check_email_recipient_limit(self):
-        if (self.email_recipient_limit <= 0 or self.email_recipient_limit > 100):
+        if (self.email_recipient_limit <= 0):
             raise ValidationError("Limit Email Recipient needs to be greater than 0 and less than 100.")
             

--- a/website_sale_product_subscribe_notify/models/res_config_settings.py
+++ b/website_sale_product_subscribe_notify/models/res_config_settings.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
+from odoo.exceptions import Warning
 
 
 class ResConfigSettings(models.TransientModel):
@@ -19,7 +20,12 @@ class ResConfigSettings(models.TransientModel):
         res = super(ResConfigSettings, self).get_values()
         email_recipient_limit = self.env['ir.default'].get('res.config.settings', 'email_recipient_limit')
         res.update(
-           email_recipient_limit = email_recipient_limit,
+            email_recipient_limit = email_recipient_limit,
         )
         return res
 
+    @api.constrains('email_recipient_limit')
+    def _check_email_recipient_limit(self):
+        if self.email_recipient_limit <= 0:
+            raise Warning("Email Recipient should be greater than 0!")
+            

--- a/website_sale_product_subscribe_notify/models/res_config_settings.py
+++ b/website_sale_product_subscribe_notify/models/res_config_settings.py
@@ -8,24 +8,27 @@ from odoo.exceptions import ValidationError
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    email_recipient_limit = fields.Integer(string='Number of Recipients Per Email')
+    email_recipient_limit = fields.Integer(
+        string='Number of Recipients Per Email')
 
     @api.multi
     def set_values(self):
         super(ResConfigSettings, self).set_values()
-        self.env['ir.default'].sudo().set('res.config.settings', 'email_recipient_limit', self.email_recipient_limit)
+        self.env['ir.default'].sudo().set('res.config.settings',
+                                          'email_recipient_limit', self.email_recipient_limit)
 
     @api.model
     def get_values(self):
         res = super(ResConfigSettings, self).get_values()
-        email_recipient_limit = self.env['ir.default'].get('res.config.settings', 'email_recipient_limit')
+        email_recipient_limit = self.env['ir.default'].get(
+            'res.config.settings', 'email_recipient_limit')
         res.update(
-            email_recipient_limit = email_recipient_limit,
+            email_recipient_limit=email_recipient_limit,
         )
         return res
 
     @api.constrains('email_recipient_limit')
     def _check_email_recipient_limit(self):
         if (self.email_recipient_limit <= 0):
-            raise ValidationError("Limit Email Recipient needs to be greater than 0.")
-            
+            raise ValidationError(
+                "Limit Email Recipient should be greater than 0.")

--- a/website_sale_product_subscribe_notify/models/res_config_settings.py
+++ b/website_sale_product_subscribe_notify/models/res_config_settings.py
@@ -27,5 +27,5 @@ class ResConfigSettings(models.TransientModel):
     @api.constrains('email_recipient_limit')
     def _check_email_recipient_limit(self):
         if (self.email_recipient_limit <= 0):
-            raise ValidationError("Limit Email Recipient needs to be greater than 0 and less than 100.")
+            raise ValidationError("Limit Email Recipient needs to be greater than 0.")
             

--- a/website_sale_product_subscribe_notify/models/res_config_settings.py
+++ b/website_sale_product_subscribe_notify/models/res_config_settings.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
-from odoo.exceptions import Warning
+from odoo.exceptions import ValidationError
 
 
 class ResConfigSettings(models.TransientModel):
@@ -26,6 +26,6 @@ class ResConfigSettings(models.TransientModel):
 
     @api.constrains('email_recipient_limit')
     def _check_email_recipient_limit(self):
-        if self.email_recipient_limit <= 0:
-            raise Warning("Email Recipient should be greater than 0!")
+        if (self.email_recipient_limit <= 0 or self.email_recipient_limit > 100):
+            raise ValidationError("Limit Email Recipient needs to be greater than 0 and less than 100.")
             

--- a/website_sale_product_subscribe_notify/models/res_config_settings.py
+++ b/website_sale_product_subscribe_notify/models/res_config_settings.py
@@ -1,0 +1,25 @@
+# Copyright 2019 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    email_recipient_limit = fields.Integer(string='Number of Recipients Per Email')
+
+    @api.multi
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        self.env['ir.default'].sudo().set('res.config.settings', 'email_recipient_limit', self.email_recipient_limit)
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+        email_recipient_limit = self.env['ir.default'].get('res.config.settings', 'email_recipient_limit')
+        res.update(
+           email_recipient_limit = email_recipient_limit,
+        )
+        return res
+

--- a/website_sale_product_subscribe_notify/views/res_config_settings_views.xml
+++ b/website_sale_product_subscribe_notify/views/res_config_settings_views.xml
@@ -4,14 +4,21 @@
     <record id="res_config_settings_view_form" model="ir.ui.view">
         <field name="name">res.config.settings.view.form</field>
         <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='website_forum_setting']" position="after">
-                <div class="o_setting_right_pane">
-                    <div class="content-group">
-                        <div class="row mt16">
-                            <label class="col-md-6 o_light_label" string="Limit Email Recipients"/>
-                            <span class="col-md-3"><field name="email_recipient_limit"/></span>
+            <xpath expr="//div[@id='emails']" position="after">
+                <div id="emails" position='replace'>
+                    <h2>Odoo Product Subscribe Notify</h2>
+                    <div class="row mt16 o_settings_container">
+                        <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="o_setting_left_pane"/>
+                            <div class="o_setting_right_pane row mt16">
+                                <label string="Limit Email Recipient"/>
+                                <div class="text-muted">
+                                    To set the maximun of recipients per email record of Odoo Product Subscribe Notify 
+                                </div>
+                                <span class="col-md-3"><field name="email_recipient_limit"/></span>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/website_sale_product_subscribe_notify/views/res_config_settings_views.xml
+++ b/website_sale_product_subscribe_notify/views/res_config_settings_views.xml
@@ -17,7 +17,7 @@
                                 <div class="text-muted">
                                     To set the maximun of recipients per email record of Odoo Product Subscribe Notify 
                                 </div>
-                                <span class="col-md-3"><field name="email_recipient_limit"/></span>
+                                <span class="col-md-4"><field name="email_recipient_limit"/></span>
                             </div>
                         </div>
                     </div>

--- a/website_sale_product_subscribe_notify/views/res_config_settings_views.xml
+++ b/website_sale_product_subscribe_notify/views/res_config_settings_views.xml
@@ -13,11 +13,16 @@
                         <div class="col-xs-12 col-md-6 o_setting_box">
                             <div class="o_setting_left_pane"/>
                             <div class="o_setting_right_pane row mt16">
-                                <label string="Limit Email Recipient"/>
+                                <label string="Email Recipient Limit"/>
                                 <div class="text-muted">
-                                    To set the maximun of recipients per email record of Odoo Product Subscribe Notify 
+                                    Set the maximun of recipients per email for Odoo Product Subscribe Notify 
                                 </div>
-                                <span class="col-md-4"><field name="email_recipient_limit"/></span>
+                                <div class="content-group">
+                                    <div class="row mt16">
+                                        <label for="email_recipient_limit" class="col-md-3 o_light_label"/>
+                                        <field name="email_recipient_limit"/>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/website_sale_product_subscribe_notify/views/res_config_settings_views.xml
+++ b/website_sale_product_subscribe_notify/views/res_config_settings_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='website_forum_setting']" position="after">
+                <div class="o_setting_right_pane">
+                    <div class="content-group">
+                        <div class="row mt16">
+                            <label class="col-md-6 o_light_label" string="Limit Email Recipients"/>
+                            <span class="col-md-3"><field name="email_recipient_limit"/></span>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This is the logic of sending out the subscription emails, generating the email record with multiple recipients (email_to). I have tested it already. On MailTrap, I received emails only for 2 recipients out of 4 recipients. This problem caused , I think because of the configuration of Outgoing Mail Servers (SMTP server 'None'. SMTPDataError: 550 5.7.0 Requested action not taken: too many emails per second). What do you think?