### PR TITLE
[IMP] Add default value to website_sequence_date

### DIFF
--- a/website_sale_adj/__manifest__.py
+++ b/website_sale_adj/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Website Sales Adjustment',
-    'version': '11.0.1.1.1',
+    'version': '11.0.1.2.0',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Product',

--- a/website_sale_adj/__manifest__.py
+++ b/website_sale_adj/__manifest__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Website Sales Adjustment',
     'version': '11.0.1.2.0',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Product',
-    'license': "AGPL-3",
+    'license': "LGPL-3",
     'description': """
 This module modify the website_sale module and provide following feature(s):
  - Show product_state_id in the /shop/product page.

--- a/website_sale_adj/controllers/main.py
+++ b/website_sale_adj/controllers/main.py
@@ -1,5 +1,5 @@
 # Copyright 2019 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import http
 from odoo.http import request

--- a/website_sale_adj/models/product_template.py
+++ b/website_sale_adj/models/product_template.py
@@ -10,6 +10,7 @@ class ProductTemplate(models.Model):
 
     website_sequence_date = fields.Datetime(
         string='Website Sequence Date',
+        default=fields.Datetime.now,
     )
 
     @api.multi

--- a/website_sale_adj/models/product_template.py
+++ b/website_sale_adj/models/product_template.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2020 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models, api
 

--- a/website_sale_adj/models/res_config_settings.py
+++ b/website_sale_adj/models/res_config_settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields
 

--- a/website_sale_adj/models/sale_order.py
+++ b/website_sale_adj/models/sale_order.py
@@ -1,5 +1,5 @@
 # Copyright 2019 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta

--- a/website_sale_adj/models/website.py
+++ b/website_sale_adj/models/website.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models, api
 from odoo.http import request

--- a/website_sale_adj/tests/test_website_sale_adj.py
+++ b/website_sale_adj/tests/test_website_sale_adj.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import time
 
@@ -86,7 +86,7 @@ class WebsiteSaleAdj(common.TransactionCase):
             'website_published': True,
         })
         product_3 = self.env['product.template'].create({
-            'name': 'Test 002',
+            'name': 'Test 003',
             'website_published': True,
         })
         product_order_list = self.env['product.template'].search(

--- a/website_sale_adj/tests/test_website_sale_adj.py
+++ b/website_sale_adj/tests/test_website_sale_adj.py
@@ -75,3 +75,22 @@ class WebsiteSaleAdj(common.TransactionCase):
         self.assertEqual(product_order_list[0], self.product_2)
         self.assertEqual(product_order_list[1], self.product_3)
         self.assertEqual(product_order_list[2], self.product_1)
+
+    def test_03_create_product(self):
+        product_1 = self.env['product.template'].create({
+            'name': 'Test 001',
+            'website_published': True,
+        })
+        product_2 = self.env['product.template'].create({
+            'name': 'Test 002',
+            'website_published': True,
+        })
+        product_3 = self.env['product.template'].create({
+            'name': 'Test 002',
+            'website_published': True,
+        })
+        product_order_list = self.env['product.template'].search(
+            [], order=WebsiteSale._get_search_order(self, {}))
+        self.assertEqual(product_order_list[0], product_3)
+        self.assertEqual(product_order_list[1], product_2)
+        self.assertEqual(product_order_list[2], product_1)


### PR DESCRIPTION
Avoid the `website_sequence_date` remains empty when product is created with `website_published` is `True`.