### PR TITLE
[11.0][FIX][ADD] Added threading for delay email sent to customer

### DIFF
--- a/website_sale_adj/models/__init__.py
+++ b/website_sale_adj/models/__init__.py
@@ -4,3 +4,4 @@ from . import product_template
 from . import website
 from . import res_config_settings
 from . import sale_order
+from . import mail_thread

--- a/website_sale_adj/models/mail_thread.py
+++ b/website_sale_adj/models/mail_thread.py
@@ -1,0 +1,66 @@
+# Copyright 2019 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import threading
+from odoo import api, models, sql_db
+
+
+class MailThread(models.AbstractModel):
+    _inherit = 'mail.thread'
+
+    # Added thread method.
+    def mail_delay(self, composer=None):
+        new_cr = sql_db.db_connect(self.env.cr.dbname).cursor()
+        uid, context = self.env.uid, self.env.context
+        with api.Environment.manage():
+            self.env = api.Environment(new_cr, uid, context)
+            if composer:
+                composer = self.env['mail.compose.message'].browse(
+                    composer.id)
+                composer.send_mail()
+        new_cr.commit()
+
+    # Overwrite message_post_with_template and added thread to send email
+    # delay.
+    @api.multi
+    def message_post_with_template(self, template_id, **kwargs):
+        """ Helper method to send a mail with a template
+            :param template_id : the id of the template to render
+             to create the body of the message
+            :param **kwargs : parameter to create a mail.compose.message
+             woaerd (which inherit from mail.message)
+        """
+        # Get composition mode, or force it according
+        # to the number of record in self
+        if not kwargs.get('composition_mode'):
+            kwargs['composition_mode'] = 'comment' if len(
+                self.ids) == 1 else 'mass_mail'
+        if not kwargs.get('message_type'):
+            kwargs['message_type'] = 'notification'
+        res_id = kwargs.get('res_id', self.ids and self.ids[0] or 0)
+        res_ids = kwargs.get('res_id') and [kwargs['res_id']] or self.ids
+
+        # Create the composer
+        composer = self.env['mail.compose.message'].with_context(
+            active_id=res_id,
+            active_ids=res_ids,
+            active_model=kwargs.get('model', self._name),
+            default_composition_mode=kwargs['composition_mode'],
+            default_model=kwargs.get('model', self._name),
+            default_res_id=res_id,
+            default_template_id=template_id,
+        ).create(kwargs)
+        # Simulate the onchange (like trigger in form the view) only
+        # when having a template in single-email mode
+
+        if template_id:
+            update_values = composer.onchange_template_id(
+                template_id, kwargs['composition_mode'],
+                self._name, res_id)['value']
+            composer.write(update_values)
+        if self._context.get('update_from_so'):
+            timer = threading.Timer(
+                30.0, self.mail_delay, args=(composer))
+            timer.start()
+            return True
+        return composer.send_mail()

--- a/website_sale_adj/models/mail_thread.py
+++ b/website_sale_adj/models/mail_thread.py
@@ -5,62 +5,26 @@ import threading
 from odoo import api, models, sql_db
 
 
-class MailThread(models.AbstractModel):
-    _inherit = 'mail.thread'
+class MailComposeMessage((models.TransientModel)):
+    _inherit = 'mail.compose.message'
 
     # Added thread method.
-    def mail_delay(self, composer=None):
+    def mail_delay(self, composer=None, auto_commit=False):
         new_cr = sql_db.db_connect(self.env.cr.dbname).cursor()
         uid, context = self.env.uid, self.env.context
         with api.Environment.manage():
             self.env = api.Environment(new_cr, uid, context)
             if composer:
-                composer = self.env['mail.compose.message'].browse(
-                    composer.id)
-                composer.send_mail()
+                composer.with_context(update_from_so=False).send_mail(
+                    auto_commit=auto_commit)
         new_cr.commit()
 
-    # Overwrite message_post_with_template and added thread to send email
-    # delay.
     @api.multi
-    def message_post_with_template(self, template_id, **kwargs):
-        """ Helper method to send a mail with a template
-            :param template_id : the id of the template to render
-             to create the body of the message
-            :param **kwargs : parameter to create a mail.compose.message
-             woaerd (which inherit from mail.message)
-        """
-        # Get composition mode, or force it according
-        # to the number of record in self
-        if not kwargs.get('composition_mode'):
-            kwargs['composition_mode'] = 'comment' if len(
-                self.ids) == 1 else 'mass_mail'
-        if not kwargs.get('message_type'):
-            kwargs['message_type'] = 'notification'
-        res_id = kwargs.get('res_id', self.ids and self.ids[0] or 0)
-        res_ids = kwargs.get('res_id') and [kwargs['res_id']] or self.ids
-
-        # Create the composer
-        composer = self.env['mail.compose.message'].with_context(
-            active_id=res_id,
-            active_ids=res_ids,
-            active_model=kwargs.get('model', self._name),
-            default_composition_mode=kwargs['composition_mode'],
-            default_model=kwargs.get('model', self._name),
-            default_res_id=res_id,
-            default_template_id=template_id,
-        ).create(kwargs)
-        # Simulate the onchange (like trigger in form the view) only
-        # when having a template in single-email mode
-
-        if template_id:
-            update_values = composer.onchange_template_id(
-                template_id, kwargs['composition_mode'],
-                self._name, res_id)['value']
-            composer.write(update_values)
+    def send_mail(self, auto_commit=False):
         if self._context.get('update_from_so'):
             timer = threading.Timer(
-                30.0, self.mail_delay, args=(composer))
+                30.0, self.mail_delay, args=(self, auto_commit))
             timer.start()
             return True
-        return composer.send_mail()
+        return super(MailComposeMessage, self).send_mail(
+            auto_commit=auto_commit)


### PR DESCRIPTION
Previous Behaviour:
 - The customer gets an email for the order confirmation after the schedular run.
 - The customer is not able to get the original base format of the order confirmation email.

Current Behaviour after this PR:
- The Customer will get an email after the 30 sec of the order.
- The Customer will get a Base format of the order confirmation email for the order.

Task #[658](https://www.quartile.co/web#id=658&action=771&model=project.task&view_type=form&menu_id=505)