### PR TITLE
[1075][IMP] Add curly brackets to search_params string

### DIFF
--- a/restful/common.py
+++ b/restful/common.py
@@ -52,7 +52,9 @@ def extract_arguments(payloads, offset=0, limit=0, order=None):
     fields, domain, payload = [], [], {}
     try:
         # QRTL Edit
-        # Assume payloads is a json formatted string
+        # Assume payloads is a json formatted string with the outermost
+        # curly brackets
+        payloads = "{%s}" % payloads
         payload = json.loads(payloads)
     except JSONDecodeError as e:
         _logger.error(e)


### PR DESCRIPTION
#[1075](https://www.quartile.co/web?debug=#id=1075&action=771&model=project.task&view_type=form&menu_id=505)

Since the service does not allow to use "{}", hence we will add the brackets in the method to format it as a json string.