### PR TITLE
[1132][IMP] Add picking_type_id to purchase tree view

### DIFF
--- a/purchase_ext_sst/__init__.py
+++ b/purchase_ext_sst/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import models

--- a/purchase_ext_sst/__manifest__.py
+++ b/purchase_ext_sst/__manifest__.py
@@ -1,14 +1,12 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017-2018 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2017-2020 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Extension for purchase functions',
-    'version': '11.0.1.12.0',
+    'version': '11.0.1.12.1',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Purchase',
-    'license': "AGPL-3",
-    'description': "",
+    'license': "LGPL-3",
     'depends': [
         'hr',
         'purchase',

--- a/purchase_ext_sst/models/__init__.py
+++ b/purchase_ext_sst/models/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import request_channel
 from . import request_medium
 from . import purchase_category

--- a/purchase_ext_sst/models/hr_employee.py
+++ b/purchase_ext_sst/models/hr_employee.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields, api
 

--- a/purchase_ext_sst/models/purchase_category.py
+++ b/purchase_ext_sst/models/purchase_category.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields
 

--- a/purchase_ext_sst/models/purchase_order.py
+++ b/purchase_ext_sst/models/purchase_order.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017-2018 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError

--- a/purchase_ext_sst/models/purchase_order_line.py
+++ b/purchase_ext_sst/models/purchase_order_line.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields, api
 

--- a/purchase_ext_sst/models/purchase_order_line_hook_onchange_product_id.py
+++ b/purchase_ext_sst/models/purchase_order_line_hook_onchange_product_id.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from datetime import datetime
 

--- a/purchase_ext_sst/models/request_channel.py
+++ b/purchase_ext_sst/models/request_channel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields
 

--- a/purchase_ext_sst/models/request_medium.py
+++ b/purchase_ext_sst/models/request_medium.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields
 

--- a/purchase_ext_sst/views/purchase_order_views.xml
+++ b/purchase_ext_sst/views/purchase_order_views.xml
@@ -106,6 +106,7 @@
             </xpath>
             <xpath expr="//field[@name='name']" position="after">
                 <field name="purchase_category_id"/>
+                <field name="picking_type_id" invisible="1"/>
                 <field name="shop_id"/>
                 <field name="call_back"/>
                 <field name="request_channel_id"/>


### PR DESCRIPTION
#[1132](https://www.quartile.co/web#view_type=form&model=project.task&id=1038&active_id=1038&menu_id=)

### Background
When `shop_id` is being updated, it shall trigger the `onchange_shop_id()` and assign `picking_type_id` according the input `shop_id` value.
https://github.com/qrtl/sst-custom/blob/1693988336f29d06ca637df676ad7df259d21937/purchase_ext_sst/models/purchase_order.py#L65-L90

### Issue
Since `picking_type_id` is not preseted in the tree view, the onchange method cannot update value of the `picking_type_id`.

### Solution
Adding `picking_type_id` to the tree view.