### PR TITLE
[3474][UPD] stock_quant_internal_transfer

### DIFF
--- a/stock_quant_internal_transfer/wizard/stock_quant_transfer.py
+++ b/stock_quant_internal_transfer/wizard/stock_quant_transfer.py
@@ -20,7 +20,6 @@ class QuantTransferWizard(models.TransientModel):
             "location_id": source_location.id,
             "picking_type_id": picking_type.id,
             "location_dest_id": self.destination_location_id.id,
-            "origin": ",".join([q.display_name for q in quant_ids]),
         }
 
     @api.multi


### PR DESCRIPTION
[3474](https://www.quartile.co/web?#id=3474&action=771&model=project.task&view_type=form&menu_id=505)

Remove the part that the display_name of quant was added to origin. This function is no longer needed by the customer, and the origin is too long, causing errors during upgrade.