### PR TITLE
[3700][FIX] product_ext_sst: split purchased_by_id, evaluated_by_id, shop_id

### DIFF
--- a/product_ext_sst/__manifest__.py
+++ b/product_ext_sst/__manifest__.py
@@ -11,6 +11,7 @@
         "website_sale",
         "product_yahoo_auction_sst",
         "product_delivery_destination",
+        "purchase_shop",
         "web_widget_open_tab",
     ],
     "data": [

--- a/product_ext_sst/models/product_template.py
+++ b/product_ext_sst/models/product_template.py
@@ -1,6 +1,5 @@
 # Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
-
 from datetime import datetime
 
 from odoo import fields, models
@@ -21,7 +20,4 @@ class ProductTemplate(models.Model):
         [(num, str(num)) for num in reversed(range(1900, datetime.now().year + 1))],
     )
     model = fields.Char()
-    evaluated_by_id = fields.Many2one("hr.employee")
-    purchased_by_id = fields.Many2one("hr.employee")
-    shop_id = fields.Many2one("stock.warehouse", string="Shop Purchased")
     list_price = fields.Float(track_visibility="onchange")

--- a/product_ext_sst/views/product_template_views.xml
+++ b/product_ext_sst/views/product_template_views.xml
@@ -51,7 +51,6 @@
             </xpath>
             <xpath expr="//field[@name='name']" position="after">
                 <field name="team_ids" widget="many2many_tags" />
-                <field name="evaluated_by_id" />
                 <field name="image_medium" widget="image" />
                 <field name="website_published" string="Visible in Website" />
                 <field name="public_categ_ids" widget="many2many_tags" />
@@ -71,7 +70,6 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='categ_id']" position="after">
                 <field name="team_ids" />
-                <field name="evaluated_by_id" />
                 <field name="public_categ_ids" />
             </xpath>
         </field>

--- a/product_ext_sst/views/product_template_views.xml
+++ b/product_ext_sst/views/product_template_views.xml
@@ -21,9 +21,6 @@
                         <field name="manufacturer" />
                         <field name="manufactured_year" />
                         <field name="model" />
-                        <field name="evaluated_by_id" />
-                        <field name="purchased_by_id" />
-                        <field name="shop_id" />
                     </group>
                 </group>
             </xpath>
@@ -55,8 +52,6 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="team_ids" widget="many2many_tags" />
                 <field name="evaluated_by_id" />
-                <field name="purchased_by_id" />
-                <field name="shop_id" />
                 <field name="image_medium" widget="image" />
                 <field name="website_published" string="Visible in Website" />
                 <field name="public_categ_ids" widget="many2many_tags" />
@@ -77,8 +72,6 @@
             <xpath expr="//field[@name='categ_id']" position="after">
                 <field name="team_ids" />
                 <field name="evaluated_by_id" />
-                <field name="purchased_by_id" />
-                <field name="shop_id" />
                 <field name="public_categ_ids" />
             </xpath>
         </field>

--- a/product_shelf_info/views/product_template_views.xml
+++ b/product_shelf_info/views/product_template_views.xml
@@ -22,10 +22,12 @@
                 <field name="shelf_id" />
             </xpath>
             <xpath
-        expr="//page[@name='general_information']//field[@name='evaluated_by_id']"
-        position="after"
+        expr="//page[@name='general_information']/group"
+        position="inside"
       >
-                <field name="shelf_id" />
+                <group>
+                    <field name="shelf_id" />
+                </group>
             </xpath>
         </field>
     </record>

--- a/purchase_ext_sst/models/purchase_order.py
+++ b/purchase_ext_sst/models/purchase_order.py
@@ -8,7 +8,6 @@ from odoo.exceptions import UserError
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
-    employee_id = fields.Many2one("hr.employee", "Received By")
     address = fields.Char()
     remark = fields.Text()
     date_planned = fields.Datetime(compute=False)

--- a/purchase_ext_sst/views/purchase_order_views.xml
+++ b/purchase_ext_sst/views/purchase_order_views.xml
@@ -24,11 +24,6 @@
                     class="oe_read_only"
                 />
             </xpath>
-            <xpath expr="//sheet/group" position="inside">
-                <group>
-                    <field name="employee_id" />
-                </group>
-            </xpath>
             <xpath expr="//notebook" position="before">
                 <group>
                     <field name="remark" />
@@ -70,9 +65,6 @@
                 <field name="remark" />
                 <field name="sale_prediction_amount" />
             </xpath>
-            <xpath expr="//field[@name='date_planned']" position="after">
-                <field name="employee_id" />
-            </xpath>
             <xpath expr="//field[@name='amount_untaxed']" position="attributes">
                 <attribute name="invisible">True</attribute>
             </xpath>
@@ -90,7 +82,6 @@
         <field name="inherit_id" ref="purchase.view_purchase_order_filter" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="employee_id" />
                 <field name="remark" />
             </xpath>
             <xpath expr="//filter[@name='to_approve']" position="after">

--- a/purchase_ext_sst/views/purchase_order_views.xml
+++ b/purchase_ext_sst/views/purchase_order_views.xml
@@ -16,11 +16,6 @@
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="priority" eval="22" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='product_id']" position="attributes">
-                <attribute
-                    name="context"
-                >{"default_evaluated_by_id": parent.employee_id}</attribute>
-            </xpath>
             <xpath expr="//field[@name='product_id']" position="after">
                 <button
                     name="open_product_record"

--- a/purchase_order_category/views/purchase_order_views.xml
+++ b/purchase_order_category/views/purchase_order_views.xml
@@ -6,11 +6,6 @@
         <field name="inherit_id" ref="purchase.purchase_order_form"/>
         <field name="priority" eval="20" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='product_id']" position="attributes">
-                <attribute
-                    name="context"
-                >{"default_purchase_category_id": parent.purchase_category_id}</attribute>
-            </xpath>
             <xpath expr="//sheet/group" position="inside">
                 <group>
                     <field name="purchase_category_id" />

--- a/purchase_post_code_propose_address_sst/views/purchase_order_views.xml
+++ b/purchase_post_code_propose_address_sst/views/purchase_order_views.xml
@@ -63,6 +63,7 @@
         <field name="name">request.quotation.select</field>
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.view_purchase_order_filter" />
+        <field name="priority" eval="18"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="before">
                 <field name="zipcode" />

--- a/purchase_shop/__manifest__.py
+++ b/purchase_shop/__manifest__.py
@@ -10,6 +10,7 @@
     "depends": ["hr", "purchase", "stock", "account_invoice_shop"],
     "data": [
         "views/purchase_order_views.xml",
+        "views/product_template_views.xml",
     ],
     "installable": True,
 }

--- a/purchase_shop/migrations/11.0.1.0.1/post-migration.py
+++ b/purchase_shop/migrations/11.0.1.0.1/post-migration.py
@@ -19,6 +19,6 @@ def migrate(env, version):
             """,
             (
                 tuple(MODULE_LIST),
-                "%" + field + "%",
+                "%" + field,
             ),
         )

--- a/purchase_shop/migrations/11.0.1.0.1/post-migration.py
+++ b/purchase_shop/migrations/11.0.1.0.1/post-migration.py
@@ -2,8 +2,8 @@
 
 from openupgradelib import openupgrade
 
-MODULE_LIST = ["purchase_ext_sst"]
-fields_list = ["shop_id", "purchased_by_id"]
+MODULE_LIST = ["purchase_ext_sst", "product_ext_sst"]
+fields_list = ["shop_id", "purchased_by_id", "evaluated_by_id"]
 
 
 @openupgrade.migrate()

--- a/purchase_shop/migrations/11.0.1.0.1/post-migration.py
+++ b/purchase_shop/migrations/11.0.1.0.1/post-migration.py
@@ -3,7 +3,7 @@
 from openupgradelib import openupgrade
 
 MODULE_LIST = ["purchase_ext_sst", "product_ext_sst"]
-fields_list = ["shop_id", "purchased_by_id", "evaluated_by_id"]
+fields_list = ["shop_id", "purchased_by_id", "evaluated_by_id", "employee_id",]
 
 
 @openupgrade.migrate()

--- a/purchase_shop/migrations/11.0.1.0.1/post-migration.py
+++ b/purchase_shop/migrations/11.0.1.0.1/post-migration.py
@@ -2,8 +2,8 @@
 
 from openupgradelib import openupgrade
 
-MODULE_LIST = ["purchase_ext_sst", "product_ext_sst"]
-fields_list = ["shop_id", "purchased_by_id", "evaluated_by_id", "employee_id",]
+MODULE_LIST = ["purchase_ext_sst"]
+fields_list = ["shop_id", "purchased_by_id"]
 
 
 @openupgrade.migrate()

--- a/purchase_shop/migrations/11.0.1.0.2/post-migration.py
+++ b/purchase_shop/migrations/11.0.1.0.2/post-migration.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Quartile Limited
+
+from openupgradelib import openupgrade
+
+MODULE_LIST_1 = ["purchase_ext_sst"]
+fields_list_1 = ["employee_id"]
+
+MODULE_LIST_2 = ["product_ext_sst"]
+fields_list_2 = ["shop_id", "purchased_by_id", "evaluated_by_id"]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Update the module reference in external identifiers
+    for field in fields_list_1:
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE ir_model_data
+            SET module = 'purchase_shop'
+            WHERE module IN %s AND model = 'ir.model.fields' and name LIKE %s;
+            """,
+            (
+                tuple(MODULE_LIST_1),
+                "%" + field,
+            ),
+        )
+    for field in fields_list_2:
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE ir_model_data
+            SET module = 'purchase_shop'
+            WHERE module IN %s AND model = 'ir.model.fields' and name LIKE %s;
+            """,
+            (
+                tuple(MODULE_LIST_2),
+                "%" + field,
+            ),
+        )

--- a/purchase_shop/models/__init__.py
+++ b/purchase_shop/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_invoice
 from . import hr_employee
+from . import product_template
 from . import purchase_order

--- a/purchase_shop/models/product_template.py
+++ b/purchase_shop/models/product_template.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    shop_id = fields.Many2one("stock.warehouse", string="Shop Purchased")
+    evaluated_by_id = fields.Many2one("hr.employee")
+    purchased_by_id = fields.Many2one("hr.employee")

--- a/purchase_shop/models/purchase_order.py
+++ b/purchase_shop/models/purchase_order.py
@@ -58,13 +58,19 @@ class PurchaseOrder(models.Model):
     @api.multi
     def write(self, vals):
         res = super().write(vals)
-        if "order_line" in vals or "shop_id" in vals or "purchased_by_id" in vals:
+        if (
+            "order_line" in vals
+            or "shop_id" in vals
+            or "purchased_by_id" in vals
+            or "evaluated_by_id" in vals
+        ):
             for order in self:
                 products = order.order_line.mapped("product_id")
                 products.write(
                     {
                         "shop_id": order.shop_id.id,
                         "purchased_by_id": order.purchased_by_id.id,
+                        "evaluated_by_id": order.employee_id.id,
                     }
                 )
         return res

--- a/purchase_shop/models/purchase_order.py
+++ b/purchase_shop/models/purchase_order.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
+    employee_id = fields.Many2one("hr.employee", "Received By")
     shop_id = fields.Many2one("stock.warehouse", "Shop")
     purchased_by_id = fields.Many2one("hr.employee", "Buyer")
 

--- a/purchase_shop/views/product_template_views.xml
+++ b/purchase_shop/views/product_template_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.common.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='general_information']/group" position="inside">
+                <group>
+                    <field name="evaluated_by_id" />
+                    <field name="purchased_by_id" />
+                    <field name="shop_id" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+    <record id="product_template_tree_view" model="ir.ui.view">
+        <field name="name">product.template.product.tree</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_tree_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="purchased_by_id" />
+                <field name="shop_id" />
+            </xpath>
+        </field>
+    </record>
+    <record id="product_template_search_view" model="ir.ui.view">
+        <field name="name">product.template.search</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_search_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='categ_id']" position="after">
+                <field name="purchased_by_id" />
+                <field name="shop_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/purchase_shop/views/product_template_views.xml
+++ b/purchase_shop/views/product_template_views.xml
@@ -20,6 +20,7 @@
         <field name="inherit_id" ref="product.product_template_tree_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">
+                <field name="evaluated_by_id" />
                 <field name="purchased_by_id" />
                 <field name="shop_id" />
             </xpath>
@@ -31,6 +32,7 @@
         <field name="inherit_id" ref="product.product_template_search_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='categ_id']" position="after">
+                <field name="evaluated_by_id" />
                 <field name="purchased_by_id" />
                 <field name="shop_id" />
             </xpath>

--- a/purchase_shop/views/purchase_order_views.xml
+++ b/purchase_shop/views/purchase_order_views.xml
@@ -4,12 +4,18 @@
         <field name="name">purchase.order.form.inherit</field>
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="priority" eval="21" />
         <field name="arch" type="xml">
             <field name="partner_ref" position="after">
                 <field name="shop_id"/>
             </field>
             <xpath expr="//field[@name='incoterm_id']" position="after">
                 <field name="purchased_by_id" />
+            </xpath>
+            <xpath expr="//sheet/group" position="inside">
+                <group>
+                    <field name="employee_id" />
+                </group>
             </xpath>
         </field>
     </record>
@@ -21,6 +27,9 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="shop_id" />
             </xpath>
+            <xpath expr="//field[@name='date_planned']" position="after">
+                <field name="employee_id" />
+            </xpath>
         </field>
     </record>
     <record id="view_purchase_order_filter" model="ir.ui.view">
@@ -30,6 +39,9 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="before">
                 <field name="shop_id" />
+            </xpath>
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field name="employee_id" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
[3700](https://www.quartile.co/web#id=3700&menu_id=505&action=1457&model=project.task&view_type=form)

As a follow up to https://github.com/qrtl/sst-custom/pull/348/files
The method using `context` will overwrite the existing context and may cause unexpected errors. Therefore, `evaluated_by_id` is also added to the `write` method extension.

Then, `purchase_by_id`, `evaluated_by_id` and `shop_id` are split from product_ext_sst.

